### PR TITLE
Fix plain authenticator

### DIFF
--- a/lib/kafka/sasl_plain_authenticator.rb
+++ b/lib/kafka/sasl_plain_authenticator.rb
@@ -26,7 +26,7 @@ module Kafka
              @password.to_s].join("\000").force_encoding('utf-8')
       @encoder.write_bytes(msg)
       begin
-        msg = @decoder.bytes
+        msg = @decoder.int32
         raise Kafka::Error, 'SASL PLAIN authentication failed: unknown error' unless msg
       rescue Errno::ETIMEDOUT, EOFError => e
         raise Kafka::Error, "SASL PLAIN authentication failed: #{e.message}"

--- a/lib/kafka/version.rb
+++ b/lib/kafka/version.rb
@@ -1,3 +1,3 @@
 module Kafka
-  VERSION = "0.4.2"
+  VERSION = "0.4.3"
 end


### PR DESCRIPTION
  * The response from plain authenticator is 0 (success), which causes
    @decoder.bytes to try to read 0 more bytes from the socket. This
    causes the authenticator to hang and timeout. This change just reads
    The 4 bytes from the socket